### PR TITLE
fix: multiply item quantity by price in dashboard calculations

### DIFF
--- a/MovingBox/Views/Locations/LabelItemCard.swift
+++ b/MovingBox/Views/Locations/LabelItemCard.swift
@@ -14,7 +14,7 @@ struct LabelItemCard: View {
     @State private var loadingError: Error?
     
     private var totalReplacementCost: Decimal {
-        label.inventoryItems?.reduce(0, { $0 + $1.price }) ?? 0
+        label.inventoryItems?.reduce(0, { $0 + ($1.price * Decimal($1.quantityInt)) }) ?? 0
     }
     
     var body: some View {

--- a/MovingBox/Views/Locations/LocationItemCard.swift
+++ b/MovingBox/Views/Locations/LocationItemCard.swift
@@ -14,7 +14,7 @@ struct LocationItemCard: View {
     @State private var loadingError: Error?
     
     private var totalReplacementCost: Decimal {
-        location.inventoryItems?.reduce(0, { $0 + $1.price }) ?? 0
+        location.inventoryItems?.reduce(0, { $0 + ($1.price * Decimal($1.quantityInt)) }) ?? 0
     }
     
     var body: some View {

--- a/MovingBox/Views/Other/DashboardView.swift
+++ b/MovingBox/Views/Other/DashboardView.swift
@@ -51,7 +51,7 @@ struct DashboardView: View {
     }
     
     private var totalReplacementCost: Decimal {
-        items.reduce(0, { $0 + $1.price })
+        items.reduce(0, { $0 + ($1.price * Decimal($1.quantityInt)) })
     }
 
     private let columns = [

--- a/MovingBoxTests/InventoryItemModelTests.swift
+++ b/MovingBoxTests/InventoryItemModelTests.swift
@@ -114,4 +114,103 @@ import Foundation
         #expect(item.quantityInt == 5)
         #expect(item.showInvalidQuantityAlert == false)
     }
+    
+    @Test("Test dashboard total value calculation with multiple items")
+    func testDashboardTotalValueCalculation() async throws {
+        // Create test items with different quantities and prices
+        let item1 = InventoryItem()
+        item1.price = Decimal(string: "10.00")!
+        item1.quantityInt = 2
+        
+        let item2 = InventoryItem()
+        item2.price = Decimal(string: "25.50")!
+        item2.quantityInt = 3
+        
+        let item3 = InventoryItem()
+        item3.price = Decimal(string: "100.00")!
+        item3.quantityInt = 1
+        
+        let items = [item1, item2, item3]
+        
+        // Simulate the dashboard calculation logic
+        let totalValue = items.reduce(0, { $0 + ($1.price * Decimal($1.quantityInt)) })
+        
+        // Expected: (10.00 * 2) + (25.50 * 3) + (100.00 * 1) = 20.00 + 76.50 + 100.00 = 196.50
+        let expectedTotal = Decimal(string: "196.50")!
+        #expect(totalValue == expectedTotal)
+    }
+    
+    @Test("Test dashboard total value calculation with single item")
+    func testDashboardSingleItemValueCalculation() async throws {
+        // Test the example from the issue: 50 forks at $1 each should be $50
+        let forks = InventoryItem()
+        forks.title = "Forks"
+        forks.price = Decimal(string: "1.00")!
+        forks.quantityInt = 50
+        
+        let items = [forks]
+        
+        // Simulate the dashboard calculation logic
+        let totalValue = items.reduce(0, { $0 + ($1.price * Decimal($1.quantityInt)) })
+        
+        // Expected: 1.00 * 50 = 50.00
+        let expectedTotal = Decimal(string: "50.00")!
+        #expect(totalValue == expectedTotal)
+    }
+    
+    @Test("Test dashboard total value calculation with zero quantity")
+    func testDashboardZeroQuantityValueCalculation() async throws {
+        let item = InventoryItem()
+        item.price = Decimal(string: "10.00")!
+        item.quantityInt = 0
+        
+        let items = [item]
+        
+        // Simulate the dashboard calculation logic
+        let totalValue = items.reduce(0, { $0 + ($1.price * Decimal($1.quantityInt)) })
+        
+        // Expected: 10.00 * 0 = 0.00
+        let expectedTotal = Decimal.zero
+        #expect(totalValue == expectedTotal)
+    }
+    
+    @Test("Test location value calculation with multiple items")
+    func testLocationValueCalculation() async throws {
+        let item1 = InventoryItem()
+        item1.price = Decimal(string: "15.00")!
+        item1.quantityInt = 2
+        
+        let item2 = InventoryItem()
+        item2.price = Decimal(string: "30.00")!
+        item2.quantityInt = 4
+        
+        let items = [item1, item2]
+        
+        // Simulate the location calculation logic
+        let totalValue = items.reduce(0, { $0 + ($1.price * Decimal($1.quantityInt)) })
+        
+        // Expected: (15.00 * 2) + (30.00 * 4) = 30.00 + 120.00 = 150.00
+        let expectedTotal = Decimal(string: "150.00")!
+        #expect(totalValue == expectedTotal)
+    }
+    
+    @Test("Test label value calculation with multiple items")
+    func testLabelValueCalculation() async throws {
+        let item1 = InventoryItem()
+        item1.price = Decimal(string: "5.00")!
+        item1.quantityInt = 10
+        
+        let item2 = InventoryItem()
+        item2.price = Decimal(string: "12.50")!
+        item2.quantityInt = 8
+        
+        let items = [item1, item2]
+        
+        // Simulate the label calculation logic
+        let totalValue = items.reduce(0, { $0 + ($1.price * Decimal($1.quantityInt)) })
+        
+        // Expected: (5.00 * 10) + (12.50 * 8) = 50.00 + 100.00 = 150.00
+        let expectedTotal = Decimal(string: "150.00")!
+        #expect(totalValue == expectedTotal)
+    }
 }


### PR DESCRIPTION
Fixes #152

Fixed bug where dashboard value calculations didn't multiply item quantity by price. This affected the main dashboard total, location cards, and label cards.

## Changes
- Fix totalReplacementCost calculation in DashboardView to multiply price * quantity
- Fix totalReplacementCost calculation in LocationItemCard to multiply price * quantity
- Fix totalReplacementCost calculation in LabelItemCard to multiply price * quantity
- Add comprehensive unit tests covering dashboard, location, and label value calculations

## Example
- **Before:** 50 forks at $1.00 each = $1.00 total (incorrect)
- **After:** 50 forks at $1.00 each = $50.00 total (correct)

Generated with [Claude Code](https://claude.ai/code)