### PR TITLE
Fix text truncation in InventoryItemRow for better UI support

### DIFF
--- a/MovingBox/Views/Items/InventoryItemRow.swift
+++ b/MovingBox/Views/Items/InventoryItemRow.swift
@@ -39,14 +39,20 @@ struct InventoryItemRow: View {
             }
             VStack(alignment: .leading) {
                 Text(item.title)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
 //                if item.make != "" {
 //                    Text("Make: \(item.make)")
+//                        .lineLimit(1)
+//                        .truncationMode(.tail)
 //                        .detailLabelStyle()
 //                } else {
 //                    EmptyView()
 //                }
 //                if item.model != "" {
 //                    Text("Model: \(item.model)")
+//                        .lineLimit(1)
+//                        .truncationMode(.tail)
 //                        .detailLabelStyle()
 //                } else {
 //                    EmptyView()


### PR DESCRIPTION
Fixes the bug where long strings in InventoryListView were not truncated properly.

## Changes
- Added `.lineLimit(1)` and `.truncationMode(.tail)` to item title text
- Prevents long strings from taking up excessive screen space
- Improves support for dynamic type and internationalization
- Also fixed commented-out make/model text for consistency

Fixes #150

Generated with [Claude Code](https://claude.ai/code)