### PR TITLE
Add multi-select capability to inventory list view

### DIFF
--- a/MovingBox/Views/Items/InventoryListSubView.swift
+++ b/MovingBox/Views/Items/InventoryListSubView.swift
@@ -17,6 +17,8 @@ struct InventoryListSubView: View {
     let location: InventoryLocation?
     let searchString: String
     let sortOrder: [SortDescriptor<InventoryItem>]
+    let isSelectionMode: Bool
+    @Binding var selectedItems: Set<InventoryItem>
     
     var body: some View {
         Group {
@@ -30,12 +32,31 @@ struct InventoryListSubView: View {
                 } else {
                     Section {
                         ForEach(items) { inventoryItem in
-                            NavigationLink(value: inventoryItem) {
-                                InventoryItemRow(item: inventoryItem)
-                                    .listRowInsets(EdgeInsets())
+                            if isSelectionMode {
+                                HStack {
+                                    Button(action: {
+                                        toggleSelection(for: inventoryItem)
+                                    }) {
+                                        Image(systemName: selectedItems.contains(inventoryItem) ? "checkmark.circle.fill" : "circle")
+                                            .foregroundColor(selectedItems.contains(inventoryItem) ? .blue : .gray)
+                                    }
+                                    .buttonStyle(PlainButtonStyle())
+                                    
+                                    InventoryItemRow(item: inventoryItem)
+                                        .listRowInsets(EdgeInsets())
+                                        .contentShape(Rectangle())
+                                        .onTapGesture {
+                                            toggleSelection(for: inventoryItem)
+                                        }
+                                }
+                            } else {
+                                NavigationLink(value: inventoryItem) {
+                                    InventoryItemRow(item: inventoryItem)
+                                        .listRowInsets(EdgeInsets())
+                                }
                             }
                         }
-                        .onDelete(perform: deleteItems)
+                        .onDelete(perform: isSelectionMode ? nil : deleteItems)
                     }
                 }
             }
@@ -50,10 +71,20 @@ struct InventoryListSubView: View {
         }
     }
     
-    init(location: InventoryLocation?, searchString: String = "", sortOrder: [SortDescriptor<InventoryItem>] = [SortDescriptor(\InventoryItem.title)]) {
+    init(location: InventoryLocation?, searchString: String = "", sortOrder: [SortDescriptor<InventoryItem>] = [SortDescriptor(\InventoryItem.title)], isSelectionMode: Bool = false, selectedItems: Binding<Set<InventoryItem>> = .constant([])) {
         self.location = location
         self.searchString = searchString
         self.sortOrder = sortOrder
+        self.isSelectionMode = isSelectionMode
+        self._selectedItems = selectedItems
+    }
+    
+    private func toggleSelection(for item: InventoryItem) {
+        if selectedItems.contains(item) {
+            selectedItems.remove(item)
+        } else {
+            selectedItems.insert(item)
+        }
     }
     
     @MainActor

--- a/MovingBox/Views/Items/InventoryListView.swift
+++ b/MovingBox/Views/Items/InventoryListView.swift
@@ -28,67 +28,144 @@ struct InventoryListView: View {
     @State private var analyzingImage: UIImage?
     @State private var isContextValid = true
     
+    // Selection state
+    @State private var isSelectionMode = false
+    @State private var selectedItems: Set<InventoryItem> = []
+    
     @Query private var allItems: [InventoryItem]
     
     let location: InventoryLocation?
     
     var body: some View {
-        InventoryListSubView(location: location, searchString: searchText, sortOrder: sortOrder)
+        InventoryListSubView(
+            location: location, 
+            searchString: searchText, 
+            sortOrder: sortOrder,
+            isSelectionMode: isSelectionMode,
+            selectedItems: $selectedItems
+        )
             .navigationTitle(location?.name ?? "All Items")
             .navigationDestination(for: InventoryItem.self) { inventoryItem in
                 InventoryDetailView(inventoryItemToDisplay: inventoryItem, navigationPath: $path, showSparklesButton: true)
             }
             .toolbar {
-                Menu("Sort", systemImage: "arrow.up.arrow.down") {
-                    Picker("Sort", selection: $sortOrder) {
-                        Text("Title (A-Z)")
-                            .tag([SortDescriptor(\InventoryItem.title)])
-                        Text("Title (Z-A)")
-                            .tag([SortDescriptor(\InventoryItem.title, order: .reverse)])
-                    }
-                }
-                Menu("Add Item", systemImage: "plus") {
+                Menu("Options", systemImage: isSelectionMode ? "checkmark.circle" : "ellipsis.circle") {
                     Button(action: {
-                        print("📱 InventoryListView - Add Item button tapped")
-                        print("📱 InventoryListView - Settings.isPro: \(settings.isPro)")
-                        print("📱 InventoryListView - Items count: \(allItems.count)")
-                        print("📱 InventoryListView - Creating new item")
-                        let newItem = InventoryItem(
-                            title: "",
-                            quantityString: "1",
-                            quantityInt: 1,
-                            desc: "",
-                            serial: "",
-                            model: "",
-                            make: "",
-                            location: location,
-                            label: nil,
-                            price: Decimal.zero,
-                            insured: false,
-                            assetId: "",
-                            notes: "",
-                            showInvalidQuantityAlert: false
-                        )
-                        router.navigate(to: .inventoryDetailView(item: newItem, showSparklesButton: true, isEditing: true))
-                    }) {
-                        Label("Add Manually", systemImage: "square.and.pencil")
-                    }
-                    .accessibilityIdentifier("createManually")
-                    
-                    Button(action: {
-                        if settings.shouldShowPaywallForAiScan(currentCount: allItems.filter({ $0.hasUsedAI}).count) {
-                            showingPaywall = true
-                        } else {
-                            router.navigate(to: .addInventoryItemView(location: location))
+                        isSelectionMode.toggle()
+                        if !isSelectionMode {
+                            selectedItems.removeAll()
                         }
                     }) {
-                        Label("Add from Photo", systemImage: "camera")
+                        Label(isSelectionMode ? "Cancel Selection" : "Select Items", systemImage: isSelectionMode ? "xmark" : "checkmark.circle")
                     }
-                    .accessibilityIdentifier("createFromCamera")
+                    
+                    if !isSelectionMode {
+                        Divider()
+                        Picker("Sort", selection: $sortOrder) {
+                            Text("Title (A-Z)")
+                                .tag([SortDescriptor(\InventoryItem.title)])
+                            Text("Title (Z-A)")
+                                .tag([SortDescriptor(\InventoryItem.title, order: .reverse)])
+                        }
+                    }
                 }
-                .accessibilityIdentifier("addItem")
+                
+                if !isSelectionMode {
+                    Menu("Add Item", systemImage: "plus") {
+                        Button(action: {
+                            print("📱 InventoryListView - Add Item button tapped")
+                            print("📱 InventoryListView - Settings.isPro: \(settings.isPro)")
+                            print("📱 InventoryListView - Items count: \(allItems.count)")
+                            print("📱 InventoryListView - Creating new item")
+                            let newItem = InventoryItem(
+                                title: "",
+                                quantityString: "1",
+                                quantityInt: 1,
+                                desc: "",
+                                serial: "",
+                                model: "",
+                                make: "",
+                                location: location,
+                                label: nil,
+                                price: Decimal.zero,
+                                insured: false,
+                                assetId: "",
+                                notes: "",
+                                showInvalidQuantityAlert: false
+                            )
+                            router.navigate(to: .inventoryDetailView(item: newItem, showSparklesButton: true, isEditing: true))
+                        }) {
+                            Label("Add Manually", systemImage: "square.and.pencil")
+                        }
+                        .accessibilityIdentifier("createManually")
+                        
+                        Button(action: {
+                            if settings.shouldShowPaywallForAiScan(currentCount: allItems.filter({ $0.hasUsedAI}).count) {
+                                showingPaywall = true
+                            } else {
+                                router.navigate(to: .addInventoryItemView(location: location))
+                            }
+                        }) {
+                            Label("Add from Photo", systemImage: "camera")
+                        }
+                        .accessibilityIdentifier("createFromCamera")
+                    }
+                    .accessibilityIdentifier("addItem")
+                }
             }
-            .searchable(text: $searchText)
+            .searchable(text: $searchText, isPresented: .constant(!isSelectionMode))
+            .toolbar {
+                if isSelectionMode {
+                    ToolbarItemGroup(placement: .bottomBar) {
+                        Button(action: selectAllItems) {
+                            Text("Select All")
+                        }
+                        .disabled(selectedItems.count == allItems.count)
+                        
+                        Spacer()
+                        
+                        Button(action: deleteSelectedItems) {
+                            Image(systemName: "trash")
+                        }
+                        .disabled(selectedItems.isEmpty)
+                        
+                        Spacer()
+                        
+                        Menu {
+                            ForEach(getAllLocations(), id: \.self) { location in
+                                Button(action: {
+                                    moveSelectedItems(to: location)
+                                }) {
+                                    Text(location.name)
+                                }
+                            }
+                        } label: {
+                            Image(systemName: "folder")
+                        }
+                        .disabled(selectedItems.isEmpty)
+                        
+                        Spacer()
+                        
+                        Menu {
+                            ForEach(getAllLabels(), id: \.self) { label in
+                                Button(action: {
+                                    updateSelectedItemsLabel(to: label)
+                                }) {
+                                    Text("\(label.emoji) \(label.name)")
+                                }
+                            }
+                            Button(action: {
+                                updateSelectedItemsLabel(to: nil)
+                            }) {
+                                Text("Remove Label")
+                            }
+                        } label: {
+                            Image(systemName: "tag")
+                        }
+                        .disabled(selectedItems.isEmpty)
+                    }
+                }
+            }
             .sheet(isPresented: $showingPaywall) {
                 revenueCatManager.presentPaywall(
                     isPresented: $showingPaywall,
@@ -130,6 +207,55 @@ struct InventoryListView: View {
     func handlePhotoCaptured(_ image: UIImage) {
         analyzingImage = image
         showingImageAnalysis = true
+    }
+    
+    // MARK: - Selection Functions
+    func selectAllItems() {
+        selectedItems = Set(allItems)
+    }
+    
+    func deleteSelectedItems() {
+        for item in selectedItems {
+            modelContext.delete(item)
+        }
+        try? modelContext.save()
+        selectedItems.removeAll()
+    }
+    
+    func moveSelectedItems(to location: InventoryLocation) {
+        for item in selectedItems {
+            item.location = location
+        }
+        try? modelContext.save()
+        selectedItems.removeAll()
+    }
+    
+    func updateSelectedItemsLabel(to label: InventoryLabel?) {
+        for item in selectedItems {
+            item.label = label
+        }
+        try? modelContext.save()
+        selectedItems.removeAll()
+    }
+    
+    func getAllLocations() -> [InventoryLocation] {
+        do {
+            let descriptor = FetchDescriptor<InventoryLocation>(sortBy: [SortDescriptor(\InventoryLocation.name)])
+            return try modelContext.fetch(descriptor)
+        } catch {
+            print("Error fetching locations: \(error)")
+            return []
+        }
+    }
+    
+    func getAllLabels() -> [InventoryLabel] {
+        do {
+            let descriptor = FetchDescriptor<InventoryLabel>(sortBy: [SortDescriptor(\InventoryLabel.name)])
+            return try modelContext.fetch(descriptor)
+        } catch {
+            print("Error fetching labels: \(error)")
+            return []
+        }
     }
 }
 


### PR DESCRIPTION
This PR implements multi-select functionality for the inventory list view, allowing users to:

- Select multiple inventory items simultaneously
- Perform bulk actions: select all, delete, move to location, add/update labels
- Access selection mode via toolbar menu that replaces sort/filter button
- Use checkboxes and bottom toolbar for actions (following iOS Reminders design)

Addresses #166

Generated with [Claude Code](https://claude.ai/code)